### PR TITLE
Fix package

### DIFF
--- a/cql-mode.el
+++ b/cql-mode.el
@@ -28,15 +28,14 @@
   (list
    (sql-font-lock-keywords-builder
     'font-lock-keyword-face nil
-    "insert" "into" "values" "table" "create")))
-
-(setq sql-mode-font-lock-object-name
-      ;; cql data types
-      (sql-font-lock-keywords-builder
-       'font-lock-type-face nil
-       "ascii" "bigint" "blob" "boolean" "counter" "decimal" "double"
-       "float" "inet" "int" "list" "map" "set" "text" "timestamp"
-       "uuid" "timeuuid" "varchar" "varint"))
+    "insert" "into" "values" "table" "create")
+   sql-mode-font-lock-object-name
+   ;; cql data types
+   (sql-font-lock-keywords-builder
+    'font-lock-type-face nil
+    "ascii" "bigint" "blob" "boolean" "counter" "decimal" "double"
+    "float" "inet" "int" "list" "map" "set" "text" "timestamp"
+    "uuid" "timeuuid" "varchar" "varint")))
 
 ;;;###autoload
 (define-derived-mode cql-mode prog-mode "CQL"

--- a/cql-mode.el
+++ b/cql-mode.el
@@ -22,20 +22,19 @@
 
 (require 'sql)
 
-(setq cql-mode-font-lock-keywords
-      (list
-       (sql-font-lock-keywords-builder
-        'font-lock-keyword-face nil
-        "insert" "into" "values" "table" "create")
+(defvar cql-mode-font-lock-keywords
+  (list
+   (sql-font-lock-keywords-builder
+    'font-lock-keyword-face nil
+    "insert" "into" "values" "table" "create")))
 
-     sql-mode-font-lock-object-name
-
-	 ;; cql data types
-	 (sql-font-lock-keywords-builder
-      'font-lock-type-face nil
-      "ascii" "bigint" "blob" "boolean" "counter" "decimal" "double"
-      "float" "inet" "int" "list" "map" "set" "text" "timestamp"
-      "uuid" "timeuuid" "varchar" "varint")))
+(setq sql-mode-font-lock-object-name
+      ;; cql data types
+      (sql-font-lock-keywords-builder
+       'font-lock-type-face nil
+       "ascii" "bigint" "blob" "boolean" "counter" "decimal" "double"
+       "float" "inet" "int" "list" "map" "set" "text" "timestamp"
+       "uuid" "timeuuid" "varchar" "varint"))
 
 (define-derived-mode cql-mode prog-mode "CQL"
   "cql major mode"

--- a/cql-mode.el
+++ b/cql-mode.el
@@ -20,6 +20,8 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Code:
+
 (require 'sql)
 
 (defvar cql-mode-font-lock-keywords

--- a/cql-mode.el
+++ b/cql-mode.el
@@ -36,6 +36,7 @@
        "float" "inet" "int" "list" "map" "set" "text" "timestamp"
        "uuid" "timeuuid" "varchar" "varint"))
 
+;;;###autoload
 (define-derived-mode cql-mode prog-mode "CQL"
   "cql major mode"
 
@@ -48,6 +49,7 @@
 
   )
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.cql\\'" . cql-mode))
 
 (provide 'cql-mode)

--- a/cql-mode.el
+++ b/cql-mode.el
@@ -43,9 +43,9 @@
   (set-syntax-table (copy-syntax-table sql-mode-syntax-table))
 
   (kill-local-variable 'font-lock-set-defaults)
-  (setq-localfont-lock-defaults
-              (list '(cql-mode-font-lock-keywords) nil t
-                    (sql-product-font-lock-syntax-alist)))
+  (setq font-lock-defaults
+        (list '(cql-mode-font-lock-keywords) nil t
+              (sql-product-font-lock-syntax-alist)))
 
   )
 


### PR DESCRIPTION
- Fix `setq-local`(insert space between function and symbol) and use `setq` instead of `setq-local` because `font-lock-defaults` is declared as buffer local variable. (And `setq-local` requires Emacs 24.3 or higher versions)
- Use defvar for global variable declaration
- Add autoload cookie for lazy loading
- Add meta comment
