### PR TITLE
Add TYPE keyword to syntax highlighting

### DIFF
--- a/cql-mode.el
+++ b/cql-mode.el
@@ -35,7 +35,7 @@
     "keyspace" "keyspaces" "limit" "local_one" "local_quorum" "modify"
     "of" "on" "one" "order" "password" "primary" "quorum" "rename"
     "revoke" "schema" "select" "set" "table" "to" "token" "three"
-    "truncate" "two" "unlogged" "update" "use" "using" "where" "with"
+    "truncate" "two" "type" "unlogged" "update" "use" "using" "where" "with"
     )
    sql-mode-font-lock-object-name
    ;; cql data types


### PR DESCRIPTION
I noticed that the `TYPE` keyword wasn't being highlighted. This adds it to the
list of keywords.

Fixes #5

Signed-off-by: Tim Heckman <t@heckman.io>